### PR TITLE
Update Algolia app ID

### DIFF
--- a/components/DocsSearchInput.js
+++ b/components/DocsSearchInput.js
@@ -116,8 +116,8 @@ export default function DocsSearchInput() {
             }}
             onClose={onClose}
             indexName="flareact"
-            apiKey="450e58b4ff73372d228a59a6eab57613"
-            appId="BH4D9OD16A"
+            apiKey="0568a23c9e1a694bfc16cc09bdff7ff4"
+            appId="I8H280NFES"
             navigator={{
               navigate({ suggestionUrl }) {
                 setIsOpen(false);


### PR DESCRIPTION
Algolia has migrated DocsSearch to their new Crawler interface, meaning we can now be in charge of our own index.